### PR TITLE
Ensure that reconnect creates a new access token

### DIFF
--- a/lib/misfit_gem/client.rb
+++ b/lib/misfit_gem/client.rb
@@ -42,6 +42,7 @@ module MisfitGem
     end
 
     def reconnect(token, secret)
+      @access_token = nil
       @token = token
       @secret = secret
       access_token

--- a/spec/misfit_gem_client_spec.rb
+++ b/spec/misfit_gem_client_spec.rb
@@ -15,5 +15,12 @@ describe MisfitGem::Client do
         client = MisfitGem::Client.new(opts)
       }.to raise_error(MisfitGem::InvalidArgumentError, "Missing required options: consumer_secret")
     end
-  
+
+    it "makes a new access token after reconnecting" do
+      client = described_class.new(consumer_key: 'key',
+                                   consumer_secret: 'secret')
+      token1 = client.reconnect('token1', 'secret1')
+      token2 = client.reconnect('token2', 'secret2')
+      expect(token1).not_to eq(token2)
+    end
 end


### PR DESCRIPTION
Memoized access token was preventing the use of one client instance with multiple sets of token/secret credentials.  This change just makes sure a new access token is created after reconnecting.
